### PR TITLE
Fixing "Server Error" when accessing /blog/:key/:index

### DIFF
--- a/examples/blog/handlers.coffee
+++ b/examples/blog/handlers.coffee
@@ -21,8 +21,7 @@ module.exports = async ->
   blog:
 
     # create post
-    create: async ({respond, url, data,
-    match: {path: {key}}}) ->
+    create: async ({respond, url, data, match: {path: {key}}}) ->
       blog = yield blogs.get key
       blog.posts ?= []
       index = blog.posts.length
@@ -51,25 +50,24 @@ module.exports = async ->
       blog = yield blogs.get key
       post = blog.posts?[index]
       if post?
-        context.respond 200, post
+        respond 200, post
       else
-        context.respond.not_found()
+        respond.not_found()
 
-    put: async ({respond, data,
-    match: {path: {key, index}}}) ->
+    put: async ({respond, data, match: {path: {key, index}}}) ->
       blog = yield blogs.get key
       post = blog.posts?[index]
       if post?
         blog.posts[index] = (yield data)
         respond 200
       else
-        context.respond.not_found()
+        respond.not_found()
 
     delete: async ({respond, match: {path: {key, index}}}) ->
       blog = yield blogs.get key
       post = blog.posts?[index]
       if post?
         delete blog.posts[index]
-        context.respond 200
+        respond 200
       else
-        context.respond.not_found()
+        respond.not_found()

--- a/examples/blog/test.coffee
+++ b/examples/blog/test.coffee
@@ -31,6 +31,19 @@ amen.describe "Example blogging API", (context) ->
         assert.equal title, "My First Post"
         assert.equal content, "This is my very first post."
 
+      context.test "Modify a post", ->
+
+        {response: {statusCode}} = yield post.put
+          title: "My first updated post"
+          content: "This is my very first post update."
+
+        assert.equal statusCode, 200
+
+        {data} = yield post.get()
+        {title, content, index} = yield data
+        assert.equal title, "My first updated post"
+        assert.equal content, "This is my very first post update."
+
     context.test "Get a blog", ->
 
       {data} = yield blog.get()

--- a/examples/blog/test.coffee
+++ b/examples/blog/test.coffee
@@ -16,15 +16,24 @@ amen.describe "Example blogging API", (context) ->
 
     context.test "Create a post", ->
 
-      {response: {headers: {locations}}} =
+      {response: {headers: {location}}} =
         (yield blog.create
           title: "My First Post"
           content: "This is my very first post.")
 
-      posts = (api.post location)
+      post = (api.post location)
+
+      context.test "Get a post", ->
+
+        {data} = yield post.get()
+        {title, content, index} = yield data
+        assert.equal index, 0
+        assert.equal title, "My First Post"
+        assert.equal content, "This is my very first post."
 
     context.test "Get a blog", ->
 
       {data} = yield blog.get()
       {posts} = yield data
       assert.equal posts.length, 1
+


### PR DESCRIPTION
This fixes #3. Also removes the awkward line breaks in the middle of the argument lists for the handlers.
