### PR TITLE
Fix `require("pbx")` not working

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,1 +1,1 @@
-module.exports = require "processor"
+module.exports = require "./processor"


### PR DESCRIPTION
This should fix #2. 
