### PR TITLE
Use ./lib directory for compiled sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ These components include:
 First, let's define our API:
 
 ```coffee
-Builder = require "pbx/builder"
+{Builder} = require "pbx"
 
 builder.define "blogs",
   path: "/blogs"
@@ -95,12 +95,12 @@ Let's serve up the API using the Node HTTP `createServer` method:
 
 ```coffee
 {call} = require "when/generator"
-pbx = require "pbx"
+{processor} = require "pbx"
 api = require "./api"
 
 call ->
   (require "http")
-  .createServer yield (pbx api, (-> {}))
+  .createServer yield (processor api, (-> {}))
   .listen 8080
 ```
 

--- a/examples/blog/api.coffee
+++ b/examples/blog/api.coffee
@@ -1,4 +1,4 @@
-Builder = require "../../src/builder"
+{Builder} = require "../../src"
 builder = new Builder "blog-api"
 
 builder.define "blogs",

--- a/examples/blog/handlers.coffee
+++ b/examples/blog/handlers.coffee
@@ -1,7 +1,7 @@
 async = (require "when/generator").lift
 {call} = require "when/generator"
 {Memory} = require "pirate"
-validate = require "../../src/filters/validate"
+{validate} = (require "../../src").filters
 
 make_key = -> (require "key-forge").randomKey 16, "base64url"
 

--- a/examples/blog/index.coffee
+++ b/examples/blog/index.coffee
@@ -1,5 +1,5 @@
 {call} = require "when/generator"
-processor = require "../../src/processor"
+{processor} = require "../../src"
 initialize = require "./handlers"
 api = require "./api"
 api.base_url = "http://localhost:8080"

--- a/examples/blog/test.coffee
+++ b/examples/blog/test.coffee
@@ -1,5 +1,5 @@
 {call} = require "when/generator"
-{discover} = require "../../src/client"
+{discover} = (require "../../src").client
 amen = require "amen"
 assert = require "assert"
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "pbx",
   "version": "1.0.0-alpha-13",
   "description": "Modular server implementation based on Patchboard API schema",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
-    "prepublish": "coffee --nodejs --harmony -o ./ -c src/*.*coffee",
-    "watch": "coffee --nodejs --harmony -o lib/ -cw src/*.*coffee",
+    "prepublish": "coffee --nodejs --harmony --compile -o ./lib ./src",
+    "watch": "coffee --nodejs --harmony --compile --watch -o lib/ ./src",
     "test": "coffee --nodejs --harmony test/index.coffee"
   },
   "repository": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,1 +1,9 @@
-module.exports = require "./processor"
+module.exports =
+  Builder:    require "./builder"
+  classifier: require "./classifier"
+  client:     require "./client"
+  Context:    require "./context"
+  errors:     require "./errors"
+  processor:  require "./processor"
+  filters:
+    validate: require "./filters/validate"

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -9,7 +9,7 @@ describe "PBX", (context) ->
 
   context.test "Build", ->
 
-    Builder = require "../src/builder"
+    {Builder} = require "../src"
     builder = new Builder "test"
 
     builder.define "blogs"
@@ -32,7 +32,7 @@ describe "PBX", (context) ->
 
     context.test "Classify", ->
 
-      classifier = require "../src/classifier"
+      {classifier} = require "../src"
       classify = classifier builder.api
 
       request =
@@ -48,7 +48,7 @@ describe "PBX", (context) ->
 
     # fold this into the example API
     context.test "Classify with query parameters", ->
-      classifier = require "../src/classifier"
+      {classifier} = require "../src"
       classify = classifier
         mappings:
           user:
@@ -83,7 +83,7 @@ describe "PBX", (context) ->
 
     context.test "Client", ->
 
-      {describe} = require "../src/client"
+      {describe} = (require "../src").client
       client = describe "http://localhost", builder.api
 
       assert.equal "curl -v -XGET http://localhost/blog/my-blog -H'accept: application/vnd.test.blog+json'",


### PR DESCRIPTION
This moves all the compiled sources from the top-level directory to `./lib`,
so existing top level directories are not at risk of being clobbered during
compilation.

This requires us to also change the way PBX is `require`d from other packages.
Instead of doing `require "pbx/processor"` or `require "pbx/client"`, these
modules are now properties of the main module, i.e.

```
{processor} = require "pbx"  # or (require "pbx").processor
{client} = require "pbx"
```

and so on. All the test cases and examples have been adapted to use this scheme.
